### PR TITLE
NEXT-39768 - Dispatch an event before storing the shop in the DB during the registration process

### DIFF
--- a/src/Event/BeforeRegistrationStartsEvent.php
+++ b/src/Event/BeforeRegistrationStartsEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\App\SDK\Event;
+
+use Psr\Http\Message\RequestInterface;
+use Shopware\App\SDK\Shop\ShopInterface;
+
+/**
+ * This event is fired before the registration process for new or already existing shops.
+ */
+class BeforeRegistrationStartsEvent extends AbstractAppLifecycleEvent
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly ShopInterface $shop,
+    ) {
+        parent::__construct($request, $shop);
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+
+    public function getShop(): ShopInterface
+    {
+        return $this->shop;
+    }
+}

--- a/src/Event/BeforeRegistrationStartsEvent.php
+++ b/src/Event/BeforeRegistrationStartsEvent.php
@@ -4,28 +4,9 @@ declare(strict_types=1);
 
 namespace Shopware\App\SDK\Event;
 
-use Psr\Http\Message\RequestInterface;
-use Shopware\App\SDK\Shop\ShopInterface;
-
 /**
  * This event is fired before the registration process for new or already existing shops.
  */
 class BeforeRegistrationStartsEvent extends AbstractAppLifecycleEvent
 {
-    public function __construct(
-        private readonly RequestInterface $request,
-        private readonly ShopInterface $shop,
-    ) {
-        parent::__construct($request, $shop);
-    }
-
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
-    }
-
-    public function getShop(): ShopInterface
-    {
-        return $this->shop;
-    }
 }

--- a/src/Registration/RegistrationService.php
+++ b/src/Registration/RegistrationService.php
@@ -14,6 +14,7 @@ use Shopware\App\SDK\AppConfiguration;
 use Shopware\App\SDK\Authentication\RequestVerifier;
 use Shopware\App\SDK\Authentication\ResponseSigner;
 use Shopware\App\SDK\Event\BeforeRegistrationCompletedEvent;
+use Shopware\App\SDK\Event\BeforeRegistrationStartsEvent;
 use Shopware\App\SDK\Event\RegistrationCompletedEvent;
 use Shopware\App\SDK\Exception\MissingShopParameterException;
 use Shopware\App\SDK\Exception\ShopNotFoundException;
@@ -61,9 +62,15 @@ class RegistrationService
                 $this->shopSecretGeneratorInterface->generate()
             );
 
+            $this->eventDispatcher?->dispatch(new BeforeRegistrationStartsEvent($request, $shop));
+
             $this->shopRepository->createShop($shop);
         } else {
-            $this->shopRepository->updateShop($shop->setShopUrl($queries['shop-url']));
+            $shop->setShopUrl($queries['shop-url']);
+
+            $this->eventDispatcher?->dispatch(new BeforeRegistrationStartsEvent($request, $shop));
+
+            $this->shopRepository->updateShop($shop);
         }
 
         $this->logger->info('Shop registration request received', [

--- a/tests/Event/BeforeRegistrationStartsEventTest.php
+++ b/tests/Event/BeforeRegistrationStartsEventTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Event;
+
+use Nyholm\Psr7\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\App\SDK\Event\BeforeRegistrationStartsEvent;
+use Shopware\App\SDK\Test\MockShop;
+
+#[CoversClass(BeforeRegistrationStartsEvent::class)]
+class BeforeRegistrationStartsEventTest extends TestCase
+{
+    public function testEvent(): void
+    {
+        $event = new BeforeRegistrationStartsEvent(
+            new Request('GET', 'http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890'),
+            new MockShop('shop-id', 'shop-url', 'shop-secret'),
+        );
+
+        static::assertSame('GET', $event->getRequest()->getMethod());
+        static::assertSame('http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890', (string) $event->getRequest()->getUri());
+        static::assertSame('shop-id', $event->getShop()->getShopId());
+        static::assertSame('shop-url', $event->getShop()->getShopUrl());
+        static::assertSame('shop-secret', $event->getShop()->getShopSecret());
+    }
+}

--- a/tests/Registration/RegistrationServiceTest.php
+++ b/tests/Registration/RegistrationServiceTest.php
@@ -15,12 +15,14 @@ use Shopware\App\SDK\AppConfiguration;
 use Shopware\App\SDK\Authentication\RequestVerifier;
 use Shopware\App\SDK\Authentication\ResponseSigner;
 use Shopware\App\SDK\Event\BeforeRegistrationCompletedEvent;
+use Shopware\App\SDK\Event\BeforeRegistrationStartsEvent;
 use Shopware\App\SDK\Event\RegistrationCompletedEvent;
 use Shopware\App\SDK\Exception\MissingShopParameterException;
 use Shopware\App\SDK\Exception\ShopNotFoundException;
 use Shopware\App\SDK\Registration\RandomStringShopSecretGenerator;
 use Shopware\App\SDK\Registration\RegistrationService;
 use PHPUnit\Framework\TestCase;
+use Shopware\App\SDK\Shop\ShopRepositoryInterface;
 use Shopware\App\SDK\Test\MockShop;
 use Shopware\App\SDK\Test\MockShopRepository;
 
@@ -55,19 +57,53 @@ class RegistrationServiceTest extends TestCase
 
     public function testRegisterCreate(): void
     {
-        $request = new Request('GET', 'http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890');
+        $events = [];
 
-        $response = $this->registerService->register($request);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expects(static::once())
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) use (&$events) {
+                $events[] = $event;
+            });
 
-        $shop = $this->shopRepository->getShopFromId('123');
-        static::assertNotNull($shop);
+        $shopRepository = $this->createMock(ShopRepositoryInterface::class);
 
-        static::assertEquals('123', $shop->getShopId());
-        static::assertEquals('https://my-shop.com', $shop->getShopUrl());
-        static::assertNotNull($shop->getShopSecret());
+        $registrationService = new RegistrationService(
+            $this->appConfiguration,
+            $shopRepository,
+            $this->createMock(RequestVerifier::class),
+            new ResponseSigner(),
+            new RandomStringShopSecretGenerator(),
+            new NullLogger(),
+            $eventDispatcher
+        );
+
+        $shopRepository
+            ->expects(static::once())
+            ->method('getShopFromId')
+            ->willReturn(null);
+
+        $shop = new MockShop('123', 'https://my-shop.com', '1234567890');
+
+        $shopRepository
+            ->expects(static::once())
+            ->method('createShopStruct')
+            ->willReturn($shop);
+
+        $eventDispatcher
+            ->expects(static::once())
+            ->method('dispatch');
+
+        $response = $registrationService->register(
+            new Request('GET', 'http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890')
+        );
 
         static::assertSame(200, $response->getStatusCode());
         $json = json_decode((string) $response->getBody()->getContents(), true);
+
+        static::assertCount(1, $events);
+        static::assertInstanceOf(BeforeRegistrationStartsEvent::class, $events[0]);
 
         static::assertIsArray($json);
         static::assertArrayHasKey('proof', $json);
@@ -77,14 +113,37 @@ class RegistrationServiceTest extends TestCase
 
     public function testRegisterUpdate(): void
     {
+        $events = [];
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expects(static::once())
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) use (&$events) {
+                $events[] = $event;
+            });
+
+        $registrationService = new RegistrationService(
+            $this->appConfiguration,
+            $this->shopRepository,
+            $this->createMock(RequestVerifier::class),
+            new ResponseSigner(),
+            new RandomStringShopSecretGenerator(),
+            new NullLogger(),
+            $eventDispatcher
+        );
+
         $request = new Request('GET', 'http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890');
 
         $this->shopRepository->createShop(new MockShop('123', 'https://foo.com', '1234567890'));
 
-        $this->registerService->register($request);
+        $registrationService->register($request);
 
         $shop = $this->shopRepository->getShopFromId('123');
         static::assertNotNull($shop);
+
+        static::assertCount(1, $events);
+        static::assertInstanceOf(BeforeRegistrationStartsEvent::class, $events[0]);
 
         static::assertEquals('123', $shop->getShopId());
         static::assertEquals('https://my-shop.com', $shop->getShopUrl());

--- a/tests/Registration/RegistrationServiceTest.php
+++ b/tests/Registration/RegistrationServiceTest.php
@@ -172,13 +172,14 @@ class RegistrationServiceTest extends TestCase
             $eventDispatcher
         );
 
-        $request = new Request('GET', 'http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890');
-
-        $this->shopRepository->createShop(new MockShop('123', 'https://foo.com', '1234567890'));
-
-        $registrationService->register($request);
+        $registrationService->register(
+            new Request('GET', 'http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890')
+        );
 
         $shop = $this->shopRepository->getShopFromId('123');
+
+        $this->shopRepository->updateShop($shop);
+
         static::assertNotNull($shop);
 
         static::assertCount(1, $events);
@@ -203,11 +204,12 @@ class RegistrationServiceTest extends TestCase
 
         $request = new Request('GET', 'http://localhost?shop-id=123&shop-url=https://my-shop.com&timestamp=1234567890');
 
-        $this->shopRepository->createShop(new MockShop('123', 'https://foo.com', '1234567890'));
-
         $registrationService->register($request);
 
         $shop = $this->shopRepository->getShopFromId('123');
+
+        $this->shopRepository->updateShop($shop);
+
         static::assertNotNull($shop);
 
         static::assertEquals('123', $shop->getShopId());


### PR DESCRIPTION
This PR is to dispatch an event during the registration process and before the Shop is written in the database.