### PR TITLE
NEXT-39991 - Fix registration url and create correct proof

### DIFF
--- a/src/Registration/RegistrationService.php
+++ b/src/Registration/RegistrationService.php
@@ -169,6 +169,7 @@ class RegistrationService
     {
         $sanitizedShopUrl = $this->sanitizeShopUrl($shop->getShopUrl());
 
+
         if ($shop->getShopUrl() !== $sanitizedShopUrl) {
             $shop->setShopUrl($sanitizedShopUrl);
             $this->shopRepository->updateShop($shop);

--- a/src/Registration/RegistrationService.php
+++ b/src/Registration/RegistrationService.php
@@ -66,7 +66,7 @@ class RegistrationService
 
             $this->shopRepository->createShop($shop);
         } else {
-            $shop->setShopUrl($queries['shop-url']);
+            $shop->setShopUrl($this->sanitizeShopUrl($queries['shop-url']));
 
             $this->eventDispatcher?->dispatch(new BeforeRegistrationStartsEvent($request, $shop));
 
@@ -77,7 +77,6 @@ class RegistrationService
             'shop-id' => $shop->getShopId(),
             'shop-url' => $shop->getShopUrl(),
         ]);
-
 
         $psrFactory = new Psr17Factory();
 


### PR DESCRIPTION
This PR will solve the problem when a Shop tries to register (_creation or update_) with a non-sanitized URL and creates the wrong `proof`.

The proof must be created with the Shop URL coming from the request and not from the sanitized one.

With the Shop URL sanitized, I'm referring to this merged PR: https://github.com/shopware/app-php-sdk/pull/26