### PR TITLE
feat: Change type annotation from MockShop to ShopInterface in MockShopRepository

### DIFF
--- a/src/Test/MockShopRepository.php
+++ b/src/Test/MockShopRepository.php
@@ -8,12 +8,12 @@ use Shopware\App\SDK\Shop\ShopInterface;
 use Shopware\App\SDK\Shop\ShopRepositoryInterface;
 
 /**
- * @implements ShopRepositoryInterface<MockShop>
+ * @implements ShopRepositoryInterface<ShopInterface>
  */
 class MockShopRepository implements ShopRepositoryInterface
 {
     /**
-     * @var array<string, MockShop>
+     * @var array<string, ShopInterface>
      */
     public array $shops = [];
 


### PR DESCRIPTION
It should be possible to use your own implementation of ShopInterface in tests. Static analysis currently prohibits it.