### PR TITLE
fix(iap): silence jwt token exceptions

### DIFF
--- a/src/Context/ContextResolver.php
+++ b/src/Context/ContextResolver.php
@@ -36,8 +36,9 @@ use Shopware\App\SDK\Shop\ShopInterface;
  */
 class ContextResolver
 {
-    public function __construct(private readonly InAppPurchaseProvider $inAppPurchaseProvider)
-    {
+    public function __construct(
+        private readonly ?InAppPurchaseProvider $inAppPurchaseProvider = null
+    ) {
     }
 
     /**
@@ -94,7 +95,7 @@ class ContextResolver
         if (!empty($params['in-app-purchases'])) {
             /** @var non-empty-string $inAppPurchaseString */
             $inAppPurchaseString = $params['in-app-purchases'];
-            $inAppPurchases = $this->inAppPurchaseProvider->decodePurchases($inAppPurchaseString, $shop);
+            $inAppPurchases = $this->inAppPurchaseProvider?->decodePurchases($inAppPurchaseString, $shop);
         }
 
         return new ModuleAction(
@@ -259,7 +260,7 @@ class ContextResolver
                 throw new MalformedWebhookBodyException();
             }
 
-            $inAppPurchases = $this->inAppPurchaseProvider->decodePurchases($claims['inAppPurchases'], $shop);
+            $inAppPurchases = $this->inAppPurchaseProvider?->decodePurchases($claims['inAppPurchases'], $shop);
         }
 
         return new StorefrontAction(
@@ -322,7 +323,7 @@ class ContextResolver
                 throw new MalformedWebhookBodyException();
             }
 
-            $inAppPurchases = $this->inAppPurchaseProvider->decodePurchases($source['inAppPurchases'], $shop);
+            $inAppPurchases = $this->inAppPurchaseProvider?->decodePurchases($source['inAppPurchases'], $shop);
         }
 
 

--- a/src/Context/InAppPurchase/HasMatchingDomain.php
+++ b/src/Context/InAppPurchase/HasMatchingDomain.php
@@ -12,7 +12,7 @@ use Shopware\App\SDK\Shop\ShopInterface;
 
 /**
  * @phpstan-import-type InAppPurchaseArray from InAppPurchaseProvider
- * 
+ *
  * @deprecated Will be removed with version 5.0.0, as no licence domain can be provided for validation
  */
 class HasMatchingDomain implements Constraint

--- a/src/Context/InAppPurchase/HasMatchingDomain.php
+++ b/src/Context/InAppPurchase/HasMatchingDomain.php
@@ -12,6 +12,8 @@ use Shopware\App\SDK\Shop\ShopInterface;
 
 /**
  * @phpstan-import-type InAppPurchaseArray from InAppPurchaseProvider
+ * 
+ * @deprecated Will be removed with version 5.0.0, as no licence domain can be provided for validation
  */
 class HasMatchingDomain implements Constraint
 {

--- a/src/Context/InAppPurchase/HasValidRSAJWKSignature.php
+++ b/src/Context/InAppPurchase/HasValidRSAJWKSignature.php
@@ -38,7 +38,10 @@ class HasValidRSAJWKSignature implements Constraint
         /** @var non-empty-string $pem */
         $pem = $this->convertToPem($key);
 
-        $signer = $this->getSigner($token->headers()->get('alg'));
+        /** @var string $alg */
+        $alg = $token->headers()->get('alg');
+
+        $signer = $this->getSigner($alg);
 
         (new SignedWith($signer, InMemory::plainText($pem)))->assert($token);
     }

--- a/src/Context/InAppPurchase/HasValidRSAJWKSignature.php
+++ b/src/Context/InAppPurchase/HasValidRSAJWKSignature.php
@@ -11,9 +11,8 @@ use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Signer\Rsa\Sha384;
 use Lcobucci\JWT\Signer\Rsa\Sha512;
 use Lcobucci\JWT\Token;
-use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\Constraint;
-use Lcobucci\JWT\Validation\ConstraintViolation;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Strobotti\JWK\Key\KeyInterface;
 use Strobotti\JWK\Key\Rsa as RsaKey;
 use Strobotti\JWK\KeyConverter;
@@ -27,12 +26,11 @@ class HasValidRSAJWKSignature implements Constraint
     {
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function assert(Token $token): void
     {
-        if (!$token instanceof UnencryptedToken) {
-            throw new \Exception('Token must be a plain JWT');
-        }
-
         $this->validateAlgorithm($token);
 
         $key = $this->getValidKey($token);
@@ -40,14 +38,9 @@ class HasValidRSAJWKSignature implements Constraint
         /** @var non-empty-string $pem */
         $pem = $this->convertToPem($key);
 
-        /** @var string $alg */
-        $alg = $token->headers()->get('alg');
+        $signer = $this->getSigner($token->headers()->get('alg'));
 
-        $signer = $this->getSigner($alg);
-
-        if (!$signer->verify($token->signature()->hash(), $token->payload(), InMemory::plainText($pem))) {
-            throw ConstraintViolation::error('Token signature mismatch', $this);
-        }
+        (new SignedWith($signer, InMemory::plainText($pem)))->assert($token);
     }
 
     private function validateAlgorithm(Token $token): void

--- a/src/Context/InAppPurchase/InAppPurchaseProvider.php
+++ b/src/Context/InAppPurchase/InAppPurchaseProvider.php
@@ -48,7 +48,7 @@ class InAppPurchaseProvider
             }
 
             $this->logger->error('Failed to decode in-app purchases: ' . $e->getMessage());
-            
+
             return new Collection();
         }
     }

--- a/src/Context/InAppPurchase/InAppPurchaseProvider.php
+++ b/src/Context/InAppPurchase/InAppPurchaseProvider.php
@@ -14,7 +14,7 @@ use Shopware\App\SDK\Framework\Collection;
 use Shopware\App\SDK\Shop\ShopInterface;
 
 /**
- * @phpstan-type InAppPurchaseArray=array{identifier: string, quantity: int, nextBookingDate?: string, sub: string}
+ * @phpstan-type InAppPurchaseArray array{identifier: string, quantity: int, nextBookingDate?: string, sub: string}
  */
 class InAppPurchaseProvider
 {
@@ -27,21 +27,19 @@ class InAppPurchaseProvider
     /**
      * @param non-empty-string $encodedPurchases
      * @return Collection<InAppPurchase>
-     * @throws \Exception
      */
     public function decodePurchases(string $encodedPurchases, ShopInterface $shop, bool $retried = false): Collection
     {
         try {
             $keys = $this->keyFetcher->getKey($retried);
             $signatureValidator = new HasValidRSAJWKSignature($keys);
-            $domainValidator = new HasMatchingDomain($shop);
 
             $parser = new Parser(new JoseEncoder());
             /** @var Token\Plain $token */
             $token = $parser->parse($encodedPurchases);
 
             $validator = new Validator();
-            $validator->assert($token, $signatureValidator, $domainValidator);
+            $validator->assert($token, $signatureValidator);
 
             return $this->transformClaims($token);
         } catch (\Exception $e) {
@@ -50,8 +48,8 @@ class InAppPurchaseProvider
             }
 
             $this->logger->error('Failed to decode in-app purchases: ' . $e->getMessage());
-
-            throw $e;
+            
+            return new Collection();
         }
     }
 

--- a/tests/Context/InAppPurchase/HasValidRSAJWKSignatureTest.php
+++ b/tests/Context/InAppPurchase/HasValidRSAJWKSignatureTest.php
@@ -112,7 +112,10 @@ class HasValidRSAJWKSignatureTest extends TestCase
         $token = new class () implements Token {
             public function headers(): DataSet
             {
-                return new DataSet([], '');
+                return new DataSet([
+                    'alg' => 'RS256',
+                    'kid' => JWKSHelper::getStaticKid(),
+                ], '');
             }
 
             public function isPermittedFor(string $audience): bool
@@ -157,9 +160,9 @@ class HasValidRSAJWKSignatureTest extends TestCase
         };
 
         static::expectException(\Exception::class);
-        static::expectExceptionMessage('Token must be a plain JWT');
+        static::expectExceptionMessage('You should pass a plain token');
 
-        $constraint = new HasValidRSAJWKSignature(new KeySet());
+        $constraint = new HasValidRSAJWKSignature($this->jwks);
         $constraint->assert($token);
     }
 }

--- a/tests/Context/InAppPurchase/InAppPurchaseProviderTest.php
+++ b/tests/Context/InAppPurchase/InAppPurchaseProviderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopware\App\SDK\Tests\Context\InAppPurchase;
 
-use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;

--- a/tests/Context/InAppPurchase/InAppPurchaseProviderTest.php
+++ b/tests/Context/InAppPurchase/InAppPurchaseProviderTest.php
@@ -122,9 +122,9 @@ class InAppPurchaseProviderTest extends TestCase
                 (new KeySetFactory())->createFromJSON('{"keys": [{"kty": "RSA","n": "yHenasOsOl-Vv2BmpayS1R8l5L-JN99FwaRRKXFssGTjJDwbYdbe3CqTSKqtOfdqZLzE6-bN2-Q1xqZZsgs0_zHNx7EROXNG_uQs1uuGkS6bgGhnq_2d7wzFvCsyI00CDXZxRlGjKAEhvcXormomF1jpUW08Y5tPeUvMSdEZbZxW1ydir-UrMm1RUSgJgSP-sUqLG7kTIJ6SG7cLtF8c8cHcVXFljMyiYLQHYOECj1oklwvfrfaoT3OKdKGumi39rDthXtFa0Aq1OS_P9qfZJ-yXiQlpf2RxRr3Q5EQJ8E9iqrlOndbkSq7eXne2DvvgsiNdyzRWFvxWSPSd9GZXkw","e": "AQAB","kid": "-1xljHNcPM59Qx9OcULA9LS219bsmKCZueVXhdF0N0k","use": "sig","alg": "RS256"}]}'),
             );
 
-        static::expectException(RequiredConstraintsViolated::class);
-
         $provider = new InAppPurchaseProvider($fetcher, $logger);
-        $provider->decodePurchases($token->toString(), $shop, true);
+        $decoded = $provider->decodePurchases($token->toString(), $shop, true);
+
+        static::assertEmpty($decoded);
     }
 }


### PR DESCRIPTION
There is no clear recovery path, if the provided IAP JWT is invalid. Besides logging, we shouldn't bubble the exception.