### PR TITLE
fix: mark invalid json response as authentication error

### DIFF
--- a/tests/HttpClient/AuthenticatedClientTest.php
+++ b/tests/HttpClient/AuthenticatedClientTest.php
@@ -172,4 +172,28 @@ class AuthenticatedClientTest extends TestCase
             $cache
         );
     }
+
+    public function testInvalidJsonTokenResponseThrowsException(): void
+    {
+        $mockClient = new MockClient([
+            new Response(200, [], 'not-a-json'),
+        ]);
+
+        $client = $this->getAuthenticatedClient($mockClient);
+
+        static::expectException(AuthenticationFailedException::class);
+        $client->sendRequest(new Request('GET', 'https://example.com'));
+    }
+
+    public function testMissingTokenFieldsThrowsException(): void
+    {
+        $mockClient = new MockClient([
+            new Response(200, [], '{"foo":"bar"}'),
+        ]);
+
+        $client = $this->getAuthenticatedClient($mockClient);
+        static::expectException(AuthenticationFailedException::class);
+
+        $client->sendRequest(new Request('GET', 'https://example.com'));
+    }
 }


### PR DESCRIPTION
In case of the URL responding with 200 - though with invalid access it's still considered as valid token. 

This could have been a different exception, but this is better for BC now
--
This pull request enhances error handling and validation in the `AuthenticatedClient` class and adds corresponding test cases to ensure robust behavior when dealing with invalid or malformed API responses.
