### PR TITLE
fix: missing transaction validation data and status redirect response

### DIFF
--- a/src/Context/Order/OrderTransaction.php
+++ b/src/Context/Order/OrderTransaction.php
@@ -42,4 +42,13 @@ class OrderTransaction extends ArrayStruct
         \assert(\is_array($this->data['order']));
         return new Order($this->data['order']);
     }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getValidationData(): array
+    {
+        \assert(\is_array($this->data['validationData']));
+        return $this->data['validationData'];
+    }
 }

--- a/src/Response/PaymentResponse.php
+++ b/src/Response/PaymentResponse.php
@@ -98,11 +98,19 @@ class PaymentResponse
     }
 
     /**
-     * @param self::ACTION_*|'' $status
+     * @deprecated tag:v5.0.0 - Will be removed and is replaced by {@see self::redirectUrl}
      */
-    public static function redirect(string $url, string $status = ''): ResponseInterface
+    public static function redirect(string $url): ResponseInterface
     {
-        return self::createResponse(array_filter(['redirectUrl' => $url, 'status' => $status]));
+        return self::createResponse(['redirectUrl' => $url]);
+    }
+
+    /**
+     * @param self::ACTION_* $status
+     */
+    public static function redirectUrl(string $status, string $url): ResponseInterface
+    {
+        return self::createResponse(array_filter(['status' => $status, 'redirectUrl' => $url]));
     }
 
     /**

--- a/src/Response/PaymentResponse.php
+++ b/src/Response/PaymentResponse.php
@@ -89,14 +89,20 @@ class PaymentResponse
         return self::createStatusResponse(self::ACTION_REOPEN);
     }
 
+    /**
+     * @param self::ACTION_* $status
+     */
     public static function createStatusResponse(string $status, string $message = ''): ResponseInterface
     {
         return self::createResponse(array_filter(['status' => $status, 'message' => $message]));
     }
 
-    public static function redirect(string $url): ResponseInterface
+    /**
+     * @param self::ACTION_*|'' $status
+     */
+    public static function redirect(string $url, string $status = ''): ResponseInterface
     {
-        return self::createResponse(['redirectUrl' => $url]);
+        return self::createResponse(array_filter(['redirectUrl' => $url, 'status' => $status]));
     }
 
     /**

--- a/tests/Context/Order/OrderTransactionTest.php
+++ b/tests/Context/Order/OrderTransactionTest.php
@@ -30,6 +30,9 @@ class OrderTransactionTest extends TestCase
             'customFields' => [
                 'key' => 'value',
             ],
+            'validationData' => [
+                'key' => 'value'
+            ]
         ]);
 
         static::assertSame('transaction-id', $orderTransaction->getId());
@@ -39,5 +42,7 @@ class OrderTransactionTest extends TestCase
         static::assertSame('order-id', $orderTransaction->getOrder()->getId());
         static::assertArrayHasKey('key', $orderTransaction->getCustomFields());
         static::assertSame('value', $orderTransaction->getCustomFields()['key']);
+        static::assertArrayHasKey('key', $orderTransaction->getValidationData());
+        static::assertSame('value', $orderTransaction->getValidationData()['key']);
     }
 }

--- a/tests/Response/PaymentResponseTest.php
+++ b/tests/Response/PaymentResponseTest.php
@@ -130,4 +130,12 @@ class PaymentResponseTest extends TestCase
         static::assertSame(200, $response->getStatusCode());
         static::assertSame('{"redirectUrl":"https:\/\/example.com"}', $response->getBody()->getContents());
     }
+
+    public function testRedirectWithStatus(): void
+    {
+        $response = PaymentResponse::redirect('https://example.com', PaymentResponse::ACTION_PROCESS);
+
+        static::assertSame(200, $response->getStatusCode());
+        static::assertSame('{"redirectUrl":"https:\/\/example.com","status":"process"}', $response->getBody()->getContents());
+    }
 }

--- a/tests/Response/PaymentResponseTest.php
+++ b/tests/Response/PaymentResponseTest.php
@@ -123,6 +123,9 @@ class PaymentResponseTest extends TestCase
         static::assertSame('{"message":"error"}', $response->getBody()->getContents());
     }
 
+    /**
+     * @deprecated tag:v5.0.0 - Will be removed
+     */
     public function testRedirect(): void
     {
         $response = PaymentResponse::redirect('https://example.com');
@@ -131,11 +134,11 @@ class PaymentResponseTest extends TestCase
         static::assertSame('{"redirectUrl":"https:\/\/example.com"}', $response->getBody()->getContents());
     }
 
-    public function testRedirectWithStatus(): void
+    public function testRedirectUrl(): void
     {
-        $response = PaymentResponse::redirect('https://example.com', PaymentResponse::ACTION_PROCESS);
+        $response = PaymentResponse::redirectUrl(PaymentResponse::ACTION_PROCESS, 'https://example.com');
 
         static::assertSame(200, $response->getStatusCode());
-        static::assertSame('{"redirectUrl":"https:\/\/example.com","status":"process"}', $response->getBody()->getContents());
+        static::assertSame('{"status":"process","redirectUrl":"https:\/\/example.com"}', $response->getBody()->getContents());
     }
 }


### PR DESCRIPTION
- `OrderTransaction` was missing `validationData`
- `PaymentResponse::redirect` was missing a status parameter