### PR TITLE
feat: expose customerId on OrderCustomer

### DIFF
--- a/src/Context/Order/OrderCustomer.php
+++ b/src/Context/Order/OrderCustomer.php
@@ -64,6 +64,12 @@ class OrderCustomer extends ArrayStruct
         return $this->data['customerNumber'];
     }
 
+    public function getCustomerId(): ?string
+    {
+        \assert(is_string($this->data['customerId']) || is_null($this->data['customerId']));
+        return $this->data['customerId'];
+    }
+
     public function getSalutation(): ?Salutation
     {
         \assert(is_array($this->data['salutation']) || is_null($this->data['salutation']));

--- a/tests/Context/Order/OrderCustomerTest.php
+++ b/tests/Context/Order/OrderCustomerTest.php
@@ -59,6 +59,18 @@ class OrderCustomerTest extends TestCase
         static::assertSame('foo', $customer->getCustomerNumber());
     }
 
+    public function testGetCustomerId(): void
+    {
+        $customer = new OrderCustomer(['customerId' => 'foo']);
+        static::assertSame('foo', $customer->getCustomerId());
+    }
+
+    public function testNullCustomerId(): void
+    {
+        $customer = new OrderCustomer(['customerId' => null]);
+        static::assertNull($customer->getCustomerId());
+    }
+
     public function testGetSalutation(): void
     {
         $customer = new OrderCustomer(['salutation' => ['id' => 'foo']]);


### PR DESCRIPTION
OrderCustomer carries the customer_id foreign key directly on the struct, but the only accessor for the customer relation (getCustomer()) requires the nested Customer entity which is only populated on newer Shopware versions. Add getCustomerId() so apps can read the foreign key without depending on the nested entity.

Returns nullable string — Shopware allows the FK to be null for guest orders.