### PR TITLE
feat: add getLanguage() to Order context to fetch locale info from the order

### DIFF
--- a/src/Context/Order/Language.php
+++ b/src/Context/Order/Language.php
@@ -22,7 +22,7 @@ class Language extends ArrayStruct
 
     public function getLocale(): ?Locale
     {
-        if (!isset($this->data['locale'])) {
+        if (!$this->isset('locale')) {
             return null;
         }
 
@@ -32,7 +32,7 @@ class Language extends ArrayStruct
 
     public function getTranslationCode(): ?Locale
     {
-        if (!isset($this->data['translationCode'])) {
+        if (!$this->isset('translationCode')) {
             return null;
         }
 

--- a/src/Context/Order/Language.php
+++ b/src/Context/Order/Language.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\App\SDK\Context\Order;
+
+use Shopware\App\SDK\Context\ArrayStruct;
+
+class Language extends ArrayStruct
+{
+    public function getId(): string
+    {
+        \assert(is_string($this->data['id']));
+        return $this->data['id'];
+    }
+
+    public function getName(): string
+    {
+        \assert(is_string($this->data['name']));
+        return $this->data['name'];
+    }
+
+    public function getLocale(): ?Locale
+    {
+        if (!isset($this->data['locale'])) {
+            return null;
+        }
+
+        \assert(is_array($this->data['locale']));
+        return new Locale($this->data['locale']);
+    }
+
+    public function getTranslationCode(): ?Locale
+    {
+        if (!isset($this->data['translationCode'])) {
+            return null;
+        }
+
+        \assert(is_array($this->data['translationCode']));
+        return new Locale($this->data['translationCode']);
+    }
+}

--- a/src/Context/Order/Locale.php
+++ b/src/Context/Order/Locale.php
@@ -8,9 +8,27 @@ use Shopware\App\SDK\Context\ArrayStruct;
 
 class Locale extends ArrayStruct
 {
+    public function getId(): string
+    {
+        \assert(is_string($this->data['id']));
+        return $this->data['id'];
+    }
+
     public function getCode(): string
     {
         \assert(is_string($this->data['code']));
         return $this->data['code'];
+    }
+
+    public function getName(): string
+    {
+        \assert(is_string($this->data['name']));
+        return $this->data['name'];
+    }
+
+    public function getTerritory(): string
+    {
+        \assert(is_string($this->data['territory']));
+        return $this->data['territory'];
     }
 }

--- a/src/Context/Order/Locale.php
+++ b/src/Context/Order/Locale.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\App\SDK\Context\Order;
+
+use Shopware\App\SDK\Context\ArrayStruct;
+
+class Locale extends ArrayStruct
+{
+    public function getCode(): string
+    {
+        \assert(is_string($this->data['code']));
+        return $this->data['code'];
+    }
+}

--- a/src/Context/Order/Order.php
+++ b/src/Context/Order/Order.php
@@ -160,4 +160,14 @@ class Order extends ArrayStruct
             return new OrderTransaction($transaction);
         }, $this->data['transactions']));
     }
+
+    public function getLanguage(): ?Language
+    {
+        if (!isset($this->data['language'])) {
+            return null;
+        }
+
+        \assert(\is_array($this->data['language']));
+        return new Language($this->data['language']);
+    }
 }

--- a/src/Context/Order/Order.php
+++ b/src/Context/Order/Order.php
@@ -163,7 +163,7 @@ class Order extends ArrayStruct
 
     public function getLanguage(): ?Language
     {
-        if (!isset($this->data['language'])) {
+        if (!$this->isset('language')) {
             return null;
         }
 

--- a/tests/Context/Order/LanguageTest.php
+++ b/tests/Context/Order/LanguageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\App\SDK\Tests\Context\Order;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\App\SDK\Context\Order\Language;
+
+#[CoversClass(Language::class)]
+class LanguageTest extends TestCase
+{
+    public function testGetId(): void
+    {
+        $language = new Language(['id' => 'language-id']);
+        static::assertSame('language-id', $language->getId());
+    }
+
+    public function testGetName(): void
+    {
+        $language = new Language(['name' => 'Deutsch']);
+        static::assertSame('Deutsch', $language->getName());
+    }
+
+    public function testGetLocale(): void
+    {
+        $language = new Language(['locale' => ['code' => 'de-DE']]);
+        static::assertSame('de-DE', $language->getLocale()?->getCode());
+    }
+
+    public function testGetLocaleNull(): void
+    {
+        $language = new Language([]);
+        static::assertNull($language->getLocale());
+    }
+
+    public function testGetTranslationCode(): void
+    {
+        $language = new Language(['translationCode' => ['code' => 'de-AT']]);
+        static::assertSame('de-AT', $language->getTranslationCode()?->getCode());
+    }
+
+    public function testGetTranslationCodeNull(): void
+    {
+        $language = new Language([]);
+        static::assertNull($language->getTranslationCode());
+    }
+}

--- a/tests/Context/Order/LocaleTest.php
+++ b/tests/Context/Order/LocaleTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\App\SDK\Tests\Context\Order;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\App\SDK\Context\Order\Locale;
+
+#[CoversClass(Locale::class)]
+class LocaleTest extends TestCase
+{
+    public function testGetCode(): void
+    {
+        $locale = new Locale(['code' => 'de-DE']);
+        static::assertSame('de-DE', $locale->getCode());
+    }
+}

--- a/tests/Context/Order/LocaleTest.php
+++ b/tests/Context/Order/LocaleTest.php
@@ -11,9 +11,27 @@ use Shopware\App\SDK\Context\Order\Locale;
 #[CoversClass(Locale::class)]
 class LocaleTest extends TestCase
 {
+    public function testGetId(): void
+    {
+        $locale = new Locale(['id' => 'locale-id']);
+        static::assertSame('locale-id', $locale->getId());
+    }
+
     public function testGetCode(): void
     {
         $locale = new Locale(['code' => 'de-DE']);
         static::assertSame('de-DE', $locale->getCode());
+    }
+
+    public function testGetName(): void
+    {
+        $locale = new Locale(['name' => 'German']);
+        static::assertSame('German', $locale->getName());
+    }
+
+    public function testGetTerritory(): void
+    {
+        $locale = new Locale(['territory' => 'Germany']);
+        static::assertSame('Germany', $locale->getTerritory());
     }
 }

--- a/tests/Context/Order/OrderTest.php
+++ b/tests/Context/Order/OrderTest.php
@@ -62,4 +62,24 @@ class OrderTest extends TestCase
         static::assertCount(1, $order->getTransactions());
         static::assertSame('transaction-id', $order->getTransactions()->first()?->getId());
     }
+
+    public function testGetLanguage(): void
+    {
+        $order = new Order(['language' => ['id' => 'language-id', 'locale' => ['code' => 'de-DE']]]);
+
+        static::assertSame('language-id', $order->getLanguage()?->getId());
+        static::assertSame('de-DE', $order->getLanguage()?->getLocale()?->getCode());
+    }
+
+    public function testGetLanguageReturnsNullWhenMissing(): void
+    {
+        $order = new Order([]);
+        static::assertNull($order->getLanguage());
+    }
+
+    public function testGetLanguageReturnsNullWhenNull(): void
+    {
+        $order = new Order(['language' => null]);
+        static::assertNull($order->getLanguage());
+    }
 }


### PR DESCRIPTION
We're missing locale in the context of the order
- New `Order::getLanguage(): ?Language`
- New Language and Locale structs with tests